### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         java:
+        - 11.0.3
         - 11
         - 17
     steps:
@@ -22,7 +23,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.java }}
-        distribution: adopt
+        distribution: zulu
     - name: Build
       run: mvn --batch-mode --update-snapshots --show-version install
 


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021 (https://adoptopenjdk.net). Switching the distribution to Azul Zulu. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. 

Also added are fixed (major) release version(s) such as `JDK 11.0.3`. This is often a good practice whenever a build/test triggers (push/pull events) to help determine if the latest (`JDK 11`) had failed the from the **latest build** vs something in **your code** caused (or introduced). 

**For example**, when building with `JDK 11.0.3` (fixed version) the build/tests passes (Green) and JDK 11 fails (Red) will mean that the latest `JDK 11` was the cause and not your code. 

**Note:** Other distributions such as Temurin do not support archived fixed releases prior to Sept. 2021 and many non LTS (long term support) releases if you plan to try out newer features in the language.